### PR TITLE
Add an Action class to model permissions and request codes

### DIFF
--- a/app/src/main/java/com/cesarvaliente/permissionssample/presentation/model/Action.java
+++ b/app/src/main/java/com/cesarvaliente/permissionssample/presentation/model/Action.java
@@ -1,0 +1,42 @@
+package com.cesarvaliente.permissionssample.presentation.model;
+
+import android.Manifest;
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Created by lgvalle on 27/10/15.
+ */
+public class Action {
+
+    @IntDef({ACTION_CODE_READ_CONTACTS, ACTION_CODE_SAVE_IMAGE, ACTION_CODE_SEND_SMS})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ActionCode {}
+
+    public static final int ACTION_CODE_READ_CONTACTS = 0;
+    public static final int ACTION_CODE_SAVE_IMAGE = 1;
+    public static final int ACTION_CODE_SEND_SMS = 2;
+
+    public static final Action READ_CONTACTS = new Action(ACTION_CODE_READ_CONTACTS, Manifest.permission.READ_CONTACTS);
+    public static final Action SAVE_IMAGE = new Action(ACTION_CODE_SAVE_IMAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    public static final Action SEND_SMS = new Action(ACTION_CODE_SEND_SMS, Manifest.permission.SEND_SMS);
+
+    private int code;
+    private String permission;
+
+    private Action(@ActionCode int value, String name) {
+        this.code = value;
+        this.permission = name;
+    }
+
+    @ActionCode
+    public int getCode() {
+        return code;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+}

--- a/app/src/main/java/com/cesarvaliente/permissionssample/presentation/presenter/PermissionPresenter.java
+++ b/app/src/main/java/com/cesarvaliente/permissionssample/presentation/presenter/PermissionPresenter.java
@@ -15,19 +15,15 @@
  */
 package com.cesarvaliente.permissionssample.presentation.presenter;
 
-import android.Manifest;
 import android.content.pm.PackageManager;
 
 import com.cesarvaliente.permissionssample.action.PermissionAction;
+import com.cesarvaliente.permissionssample.presentation.model.Action;
 
 /**
  * Created by Cesar on 15/09/15.
  */
 public class PermissionPresenter {
-
-    public static final int ACTION_READ_CONTACTS = 1;
-    public static final int ACTION_SAVE_IMAGE = 2;
-    public static final int ACTION_SEND_SMS = 3;
 
     private PermissionAction permissionAction;
     private PermissionCallbacks permissionCallbacks;
@@ -37,43 +33,55 @@ public class PermissionPresenter {
         this.permissionCallbacks = permissionCallbacks;
     }
 
-    public void requestReadContactsPermission(int action) {
-        checkAndRequestPermission(action, Manifest.permission.READ_CONTACTS);
+    public void requestReadContactsPermission() {
+        checkAndRequestPermission(Action.READ_CONTACTS);
     }
 
-    public void requestReadContactsPermissionAfterRationale(int action) {
-        permissionAction.requestPermission(Manifest.permission.READ_CONTACTS, action);
+    public void requestReadContactsPermissionAfterRationale() {
+        requestPermission(Action.READ_CONTACTS);
     }
 
-    public void requestWriteExternalStorangePermission(int action) {
-        checkAndRequestPermission(action, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+    public void requestWriteExternalStorangePermission() {
+        checkAndRequestPermission(Action.SAVE_IMAGE);
     }
 
-    public void requestWriteExternalStorangePermissionAfterRationale(int action) {
-        permissionAction.requestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE, action);
+    public void requestWriteExternalStorangePermissionAfterRationale() {
+        requestPermission(Action.SAVE_IMAGE);
     }
 
-    public void requestSendSMS(int action) {
-        checkAndRequestPermission(action, Manifest.permission.SEND_SMS);
+    public void requestSendSMS() {
+        checkAndRequestPermission(Action.SEND_SMS);
     }
 
-    public void requestSendSMSAfterRationale(int action) {
-        permissionAction.requestPermission(Manifest.permission.SEND_SMS, action);
+    public void requestSendSMSAfterRationale() {
+        requestPermission(Action.SEND_SMS);
     }
 
-    private void checkAndRequestPermission(int action, String permission) {
-        if (permissionAction.hasSelfPermission(permission)) {
-            permissionCallbacks.permissionAccepted(action);
+    private void checkAndRequestPermission(Action action) {
+        if (permissionAction.hasSelfPermission(action.getPermission())) {
+            permissionCallbacks.permissionAccepted(action.getCode());
         } else {
-            if (permissionAction.shouldShowRequestPermissionRationale(permission)) {
-                permissionCallbacks.showRationale(action);
+            if (permissionAction.shouldShowRequestPermissionRationale(action.getPermission())) {
+                permissionCallbacks.showRationale(action.getCode());
             } else {
-                permissionAction.requestPermission(permission, action);
+                permissionAction.requestPermission(action.getPermission(), action.getCode());
             }
         }
     }
 
-    public boolean verifyGrantedPermission(int[] grantResults) {
+    private void requestPermission(Action action) {
+        permissionAction.requestPermission(action.getPermission(), action.getCode());
+    }
+
+    public void checkGrantedPermission(int[] grantResults, int requestCode) {
+        if (verifyGrantedPermission(grantResults)) {
+            permissionCallbacks.permissionAccepted(requestCode);
+        } else {
+            permissionCallbacks.permissionDenied(requestCode);
+        }
+    }
+
+    private boolean verifyGrantedPermission(int[] grantResults) {
         for (int result : grantResults) {
             if (result != PackageManager.PERMISSION_GRANTED) {
                 return false;
@@ -83,10 +91,10 @@ public class PermissionPresenter {
     }
 
     public interface PermissionCallbacks {
-        void permissionAccepted(int action);
+        void permissionAccepted(@Action.ActionCode int actionCode);
 
-        void permissionDenied(int action);
+        void permissionDenied(@Action.ActionCode int actionCode);
 
-        void showRationale(int action);
+        void showRationale(@Action.ActionCode int actionCode);
     }
 }

--- a/app/src/main/java/com/cesarvaliente/permissionssample/presentation/view/MainActivity.java
+++ b/app/src/main/java/com/cesarvaliente/permissionssample/presentation/view/MainActivity.java
@@ -22,22 +22,21 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ProgressBar;
 
-import butterknife.Bind;
-import butterknife.ButterKnife;
 import com.cesarvaliente.permissionssample.R;
 import com.cesarvaliente.permissionssample.action.PermissionAction;
 import com.cesarvaliente.permissionssample.action.impl.permission.PermissionActionFactory;
 import com.cesarvaliente.permissionssample.presentation.BaseActivity;
+import com.cesarvaliente.permissionssample.presentation.model.Action;
 import com.cesarvaliente.permissionssample.presentation.model.ContactModel;
 import com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter;
 import com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter.PermissionCallbacks;
 import com.cesarvaliente.permissionssample.presentation.view.contact.ContactFragment;
 import com.cesarvaliente.permissionssample.presentation.view.contactlist.ContactListFragment;
 
+import butterknife.Bind;
+import butterknife.ButterKnife;
+
 import static com.cesarvaliente.permissionssample.action.impl.permission.PermissionActionFactory.SUPPORT_IMPL;
-import static com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter.ACTION_READ_CONTACTS;
-import static com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter.ACTION_SAVE_IMAGE;
-import static com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter.ACTION_SEND_SMS;
 
 
 public class MainActivity extends BaseActivity implements MainView, PermissionCallbacks {
@@ -125,18 +124,17 @@ public class MainActivity extends BaseActivity implements MainView, PermissionCa
 
     @Override
     public void requestReadContacts() {
-        permissionPresenter.requestReadContactsPermission(ACTION_READ_CONTACTS);
+        permissionPresenter.requestReadContactsPermission();
     }
 
     @Override
     public void requestSaveImage() {
-        permissionPresenter.requestWriteExternalStorangePermission(PermissionPresenter
-                .ACTION_SAVE_IMAGE);
+        permissionPresenter.requestWriteExternalStorangePermission();
     }
 
     @Override
     public void requestSendSMS() {
-        permissionPresenter.requestSendSMS(PermissionPresenter.ACTION_SEND_SMS);
+        permissionPresenter.requestSendSMS();
     }
 
     //----- Permission management ----//
@@ -144,27 +142,23 @@ public class MainActivity extends BaseActivity implements MainView, PermissionCa
     @Override
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
         switch (requestCode) {
-        case ACTION_READ_CONTACTS:
-        case ACTION_SAVE_IMAGE:
-        case ACTION_SEND_SMS:
-            if (permissionPresenter.verifyGrantedPermission(grantResults)) {
-                permissionAccepted(requestCode);
-            } else {
-                permissionDenied(requestCode);
-            }
+        case Action.ACTION_CODE_READ_CONTACTS:
+        case Action.ACTION_CODE_SAVE_IMAGE:
+        case Action.ACTION_CODE_SEND_SMS:
+            permissionPresenter.checkGrantedPermission(grantResults, requestCode);
         }
     }
 
     @Override
     public void permissionAccepted(int action) {
         switch (action) {
-        case ACTION_READ_CONTACTS:
+        case Action.ACTION_CODE_READ_CONTACTS:
             contactListFragment.getPhoneBookContacts();
             break;
-        case ACTION_SAVE_IMAGE:
+        case Action.ACTION_CODE_SAVE_IMAGE:
             contactFragment.saveImage();
             break;
-        case ACTION_SEND_SMS:
+        case Action.ACTION_CODE_SEND_SMS:
             contactFragment.sendSMS();
             break;
         }
@@ -180,15 +174,15 @@ public class MainActivity extends BaseActivity implements MainView, PermissionCa
     @Override
     public void showRationale(int action) {
         switch (action) {
-        case ACTION_READ_CONTACTS:
+        case Action.ACTION_CODE_READ_CONTACTS:
             createAndShowPermissionRationale(action, R.string.rationale_read_contacts_title, R.string
                     .rationale_read_contacts_subtitle);
             break;
-        case ACTION_SAVE_IMAGE:
+        case Action.ACTION_CODE_SAVE_IMAGE:
             createAndShowPermissionRationale(action, R.string.rationale_save_image_title, R.string
                     .rationale_save_image_subtitle);
             break;
-        case ACTION_SEND_SMS:
+        case Action.ACTION_CODE_SEND_SMS:
             createAndShowPermissionRationale(action, R.string.rationale_send_sms_title, R.string
                     .rationale_send_sms_subtitle);
             break;
@@ -198,14 +192,14 @@ public class MainActivity extends BaseActivity implements MainView, PermissionCa
     public void onAcceptRationaleClick(View view) {
         int action = dismissPermissionRationale();
         switch (action) {
-        case ACTION_READ_CONTACTS:
-            permissionPresenter.requestReadContactsPermissionAfterRationale(action);
+        case Action.ACTION_CODE_READ_CONTACTS:
+            permissionPresenter.requestReadContactsPermissionAfterRationale();
             break;
-        case ACTION_SAVE_IMAGE:
-            permissionPresenter.requestWriteExternalStorangePermissionAfterRationale(action);
+        case Action.ACTION_CODE_SAVE_IMAGE:
+            permissionPresenter.requestWriteExternalStorangePermissionAfterRationale();
             break;
-        case ACTION_SEND_SMS:
-            permissionPresenter.requestSendSMSAfterRationale(action);
+        case Action.ACTION_CODE_SEND_SMS:
+            permissionPresenter.requestSendSMSAfterRationale();
             break;
         }
     }
@@ -213,13 +207,13 @@ public class MainActivity extends BaseActivity implements MainView, PermissionCa
     @Override
     protected void showSnackBarPermissionMessage(int action) {
         switch (action) {
-        case ACTION_READ_CONTACTS:
+        case Action.ACTION_CODE_READ_CONTACTS:
             super.showSnackBarPermissionMessage(R.string.snackbar_read_contacts);
             break;
-        case ACTION_SAVE_IMAGE:
+        case Action.ACTION_CODE_SAVE_IMAGE:
             super.showSnackBarPermissionMessage(R.string.snackbar_save_image);
             break;
-        case ACTION_SEND_SMS:
+        case Action.ACTION_CODE_SEND_SMS:
             super.showSnackBarPermissionMessage(R.string.snackbar_sms);
             break;
         }

--- a/app/src/test/java/com/cesarvaliente/permissionssample/presentation/presenter/PermissionPresenterTest.java
+++ b/app/src/test/java/com/cesarvaliente/permissionssample/presentation/presenter/PermissionPresenterTest.java
@@ -15,6 +15,10 @@
  */
 package com.cesarvaliente.permissionssample.presentation.presenter;
 
+import com.cesarvaliente.permissionssample.action.PermissionAction;
+import com.cesarvaliente.permissionssample.presentation.model.Action;
+import com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter.PermissionCallbacks;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,11 +26,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import com.cesarvaliente.permissionssample.action.PermissionAction;
-import com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter.PermissionCallbacks;
-
 import static android.Manifest.permission.READ_CONTACTS;
-import static com.cesarvaliente.permissionssample.presentation.presenter.PermissionPresenter.ACTION_READ_CONTACTS;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -51,8 +51,8 @@ public class PermissionPresenterTest {
     public void shouldCallAcceptedPermission() {
         when(permissionAction.hasSelfPermission(READ_CONTACTS)).thenReturn(true);
 
-        permissionPresenter.requestReadContactsPermission(ACTION_READ_CONTACTS);
-        verify(permissionCallbacks).permissionAccepted(ACTION_READ_CONTACTS);
+        permissionPresenter.requestReadContactsPermission();
+        verify(permissionCallbacks).permissionAccepted(Action.ACTION_CODE_READ_CONTACTS);
     }
 
     @Test
@@ -60,8 +60,8 @@ public class PermissionPresenterTest {
         when(permissionAction.hasSelfPermission(READ_CONTACTS)).thenReturn(false);
         when(permissionAction.shouldShowRequestPermissionRationale(READ_CONTACTS)).thenReturn(true);
 
-        permissionPresenter.requestReadContactsPermission(ACTION_READ_CONTACTS);
-        verify(permissionCallbacks).showRationale(ACTION_READ_CONTACTS);
+        permissionPresenter.requestReadContactsPermission();
+        verify(permissionCallbacks).showRationale(Action.ACTION_CODE_READ_CONTACTS);
     }
 
     @Test
@@ -69,7 +69,7 @@ public class PermissionPresenterTest {
         when(permissionAction.hasSelfPermission(READ_CONTACTS)).thenReturn(false);
         when(permissionAction.shouldShowRequestPermissionRationale(READ_CONTACTS)).thenReturn(false);
 
-        permissionPresenter.requestReadContactsPermission(ACTION_READ_CONTACTS);
-        verify(permissionAction).requestPermission(READ_CONTACTS, ACTION_READ_CONTACTS);
+        permissionPresenter.requestReadContactsPermission();
+        verify(permissionAction).requestPermission(READ_CONTACTS, Action.ACTION_CODE_READ_CONTACTS);
     }
 }


### PR DESCRIPTION
- Add `Action` class to group together action request codes and related permission. 
  - Request codes are annotated with `@ActionCode` to help preventing errors.
- Add method `checkGrantedPermission()` to verify if a permission has been granted and callback to appropriate method: `permissionAccepted()` or `permissionDenied()`
- `verifyGrantedPermission()` is now private as it is used only internally
